### PR TITLE
Fix typo in Chromium option

### DIFF
--- a/Home Assistant Panel and Photo Frame/start-kiosk.sh
+++ b/Home Assistant Panel and Photo Frame/start-kiosk.sh
@@ -7,6 +7,6 @@ URL="http://0.0.0.0:8123/remote-control-panel/0"
 pkill -o -f chromium
 sleep 2
 
-chromium-browser --kiosk --disable-pinch --disable-translate --noerrdialogs --disable-infobars --disable-session-crashed-bubble --disble-component-update --app="http://0.0.0.0:8123/remote-control-panel/0"
+chromium-browser --kiosk --disable-pinch --disable-translate --noerrdialogs --disable-infobars --disable-session-crashed-bubble --disable-component-update --app="http://0.0.0.0:8123/remote-control-panel/0"
 
 


### PR DESCRIPTION
## Summary
- correct typo in start-kiosk.sh Chromium launch options

## Testing
- `grep -n component-update 'Home Assistant Panel and Photo Frame/start-kiosk.sh'`

------
https://chatgpt.com/codex/tasks/task_e_6841cf0254fc832ba174d76bf24f6809